### PR TITLE
Fix: Geo country name on tool tip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "location-geo-map",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "scripts": {
     "start": "nr1 nerdpack:serve",
     "prettier": "prettier --write ."

--- a/visualizations/store-map-viz/components/LocationPopup.tsx
+++ b/visualizations/store-map-viz/components/LocationPopup.tsx
@@ -3,16 +3,20 @@ import { Tooltip } from "react-leaflet";
 
 const LocationPopup = ({ location, config, title, sticky }) => {
   const items = config.map((item) => {
-    return (
-      <>
-        <div className="popup-label">{item.label}:</div>
-        <div>
-          {typeof item.formatFn === "function"
-            ? item.formatFn?.(location[item.queryField])
-            : location[item.queryField]}
-        </div>
-      </>
-    );
+    if(!location[item.queryField]) {
+      return null;
+    } else {
+      return (
+        <>
+          <div className="popup-label">{item.label}:</div>
+          <div>
+            {typeof item.formatFn === "function"
+              ? item.formatFn?.(location[item.queryField])
+              : location[item.queryField]}
+          </div>
+        </>
+      );
+    }
   });
 
   return (

--- a/visualizations/store-map-viz/components/LocationPopup.tsx
+++ b/visualizations/store-map-viz/components/LocationPopup.tsx
@@ -1,30 +1,45 @@
 import React from "react";
 import { Tooltip } from "react-leaflet";
 
-const LocationPopup = ({ location, config, title, sticky }) => {
-  const items = config.map((item) => {
-    if(!location[item.queryField]) {
-      return null;
-    } else {
-      return (
-        <>
-          <div className="popup-label">{item.label}:</div>
-          <div>
-            {typeof item.formatFn === "function"
-              ? item.formatFn?.(location[item.queryField])
-              : location[item.queryField]}
-          </div>
-        </>
-      );
-    }
+type AttributesListProps = {
+  location: any;
+  config: any;
+};
+
+type LocationPopupProps = {
+  location: any;
+  config: any;
+  title?: string;
+  sticky?: boolean;
+};
+
+const AttributesList = ({ location, config }: AttributesListProps) => {
+  const items = config.map((item, index) => {
+    const value = location[item.queryField];
+    const formattedValue =
+      typeof item.formatFn === "function" ? item.formatFn(value) : value;
+
+    return value ? (
+      <React.Fragment key={index}>
+        <div className="popup-label">{item.label}:</div>
+        <div>{formattedValue}</div>
+      </React.Fragment>
+    ) : null;
   });
 
-  return (
-    <Tooltip sticky={sticky}>
-      {title && title !== "" && <h4>{title}</h4>}
-      <div className="popup-grid">{items}</div>
-    </Tooltip>
-  );
+  return <div className="popup-grid">{items}</div>;
 };
+
+const LocationPopup = ({
+  location,
+  config,
+  title,
+  sticky,
+}: LocationPopupProps) => (
+  <Tooltip sticky={sticky}>
+    {title && <h4>{title}</h4>}
+    <AttributesList location={location} config={config} />
+  </Tooltip>
+);
 
 export default LocationPopup;

--- a/visualizations/store-map-viz/hooks/useRegionFeature.tsx
+++ b/visualizations/store-map-viz/hooks/useRegionFeature.tsx
@@ -1,21 +1,51 @@
 import { useMemo } from "react";
 
-import countries from "../geo/countries.geojson.json";
+import countriesData from "../geo/countries.geojson.json";
 import geoUSStates from "../geo/us-states/us-states";
 import allUKRegions from "../geo/uk-regions/all-uk-regions";
 
-const useRegionFeature = (location) => {
+interface Location {
+  geoISOCountry?: string;
+  geoUSState?: string;
+  geoUKRegion?: string;
+}
+
+interface GeoJSONFeatureCollection {
+  type: "FeatureCollection";
+  features: GeoJSONFeature[];
+}
+
+interface GeoJSONFeature {
+  name?: string;
+  properties?: {
+    ADMIN?: string;
+    ISO_A3?: string;
+    ISO_A2?: string;
+    STATECODE?: string;
+    STATE?: string;
+    NAME?: string;
+  };
+  geometry?: {
+    type: string;
+    coordinates: number[][] | number[][][] | number[][][][];
+  };
+}
+
+const countries: GeoJSONFeatureCollection =
+  countriesData as GeoJSONFeatureCollection;
+
+const useRegionFeature = (location: Location): GeoJSONFeature | null => {
   return useMemo(() => {
-    let feature = null;
+    let feature: GeoJSONFeature | undefined = undefined;
 
     if (location.geoISOCountry) {
-      feature = countries.features.find((f) =>
-        [f.properties.ISO_A3, f.properties.ISO_A2].includes(
-          location.geoISOCountry,
-        ),
+      feature = countries.features.find((f: GeoJSONFeature) =>
+        [f.properties?.ISO_A3, f.properties?.ISO_A2].includes(
+          location.geoISOCountry
+        )
       );
       if (feature) {
-        feature.name = feature.properties.ADMIN;
+        feature.name = feature.properties?.ADMIN || "";
       }
     } else if (location.geoUSState) {
       feature = geoUSStates.features.find((f) =>
@@ -23,16 +53,16 @@ const useRegionFeature = (location) => {
           f.properties.STATECODE,
           f.properties.STATE,
           f.properties.NAME,
-        ].includes(location.geoUSState),
+        ].includes(location.geoUSState)
       );
       if (feature) {
-        feature.name = feature.properties.NAME;
+        feature.name = feature.properties?.NAME || "";
       }
     } else if (location.geoUKRegion) {
       feature = allUKRegions.find((r) => r.name === location.geoUKRegion);
     }
 
-    return feature;
+    return feature || null;
   }, [location.geoISOCountry, location.geoUSState, location.geoUKRegion]);
 };
 

--- a/visualizations/store-map-viz/hooks/useRegionFeature.tsx
+++ b/visualizations/store-map-viz/hooks/useRegionFeature.tsx
@@ -15,7 +15,7 @@ const useRegionFeature = (location) => {
         ),
       );
       if (feature) {
-        feature.name = feature.properties.NAME;
+        feature.name = feature.properties.ADMIN;
       }
     } else if (location.geoUSState) {
       feature = geoUSStates.features.find((f) =>


### PR DESCRIPTION
Fixes problem where country name was missing on country region tooltips when no overriding tilte was supplied. (It worked on US States)

Also fixes empty "Name:"  entry on tool tip.

Fixes issue:  #12 